### PR TITLE
1. fix : CliInterface::handleLine 100% parsed as 0% 2. fix: CliPlugin::isWrongPasswordMsg The specified password is incorrect missing.

### DIFF
--- a/kerfuffle/cliinterface.cpp
+++ b/kerfuffle/cliinterface.cpp
@@ -840,7 +840,7 @@ bool CliInterface::handleLine(const QString& line)
         //read the percentage
         int pos = line.indexOf(QLatin1Char( '%' ));
         if (pos > 1) {
-            int percentage = line.midRef(pos - 2, 2).toInt();
+            int percentage = line.midRef(pos - 3, 3).toInt();
             emit progress(float(percentage) / 100);
             return true;
         }

--- a/plugins/clirarplugin/cliplugin.cpp
+++ b/plugins/clirarplugin/cliplugin.cpp
@@ -590,7 +590,7 @@ bool CliPlugin::isPasswordPrompt(const QString &line)
 
 bool CliPlugin::isWrongPasswordMsg(const QString &line)
 {
-    return (line.contains(QLatin1String("password incorrect")) || line.contains(QLatin1String("wrong password")));
+    return (line.contains(QLatin1String("password incorrect")) || line.contains(QLatin1String("wrong password"))) || line.contains(QLatin1String("The specified password is incorrect")));
 }
 
 bool CliPlugin::isCorruptArchiveMsg(const QString &line)


### PR DESCRIPTION
1. fix : CliInterface::handleLine 100% parsed as 0%
2. fix: CliPlugin::isWrongPasswordMsg The specified password is incorrect missing.